### PR TITLE
style(checkstyle): exclude `.m2/` and `.jdk/` folders from `nohttp-checkstyle-validation` rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
               <encoding>UTF-8</encoding>
               <sourceDirectories>${basedir}</sourceDirectories>
               <includes>**/*</includes>
-              <excludes>**/.git/**/*,**/.idea/**/*,**/target/**/,**/.flattened-pom.xml,**/*.class</excludes>
+              <excludes>**/.m2/**/*,**/.jdk/**/*,**/.git/**/*,**/.idea/**/*,**/target/**/,**/.flattened-pom.xml,**/*.class</excludes>
             </configuration>
             <goals>
               <goal>check</goal>


### PR DESCRIPTION
#1 